### PR TITLE
Add slide template and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ editableSlides:
 - `fixedSlides` セクションはテンプレートとして固定されており、通常は変更不要です。
 - スライドの種類（`type`）によって利用できるプロパティが異なります。
 
+## スライドテンプレートの利用方法
+
+本リポジトリには `slides_template.yaml` を同梱しています。新しいプレゼンテーションを作成する際はこのファイルをコピーし、内容を編集して `slides.yaml` として保存してください。
+
+### 利用できる型一覧
+
+| type | 主なプロパティ | 説明 |
+|------|----------------|------|
+| `title` | `title`, `author`, `date`, `notes` | タイトルスライド |
+| `list` | `header`, `title`, `content`, `footerText` | 箇条書きのスライド。`content` 配下に `text` などを記入します |
+| `code` | `header`, `title`, `language`, `code`, `zoomable` | ソースコードを表示します |
+| `pointCloud` | `header`, `title`, `points`, `fileInputId`, `zoomable` | 点群データを three.js で描画します |
+| `image` | `header`, `title`, `imageSrc`, `fileInputId`, `zoomable` | 画像の表示用スライド |
+| `video` | `header`, `title`, `videoId`, `fileInputId`, `zoomable` | YouTube もしくはローカル動画を再生します |
+| `end` | `title` | 終了画面 |
+
+各型のプロパティは必要に応じて追加できます。詳しくは `slides_template.yaml` のコメントを参考にしてください。
+
 変更を保存したら、ブラウザをリロードすることで更新後のスライドを確認できます。
 
 ## ライセンス

--- a/slides_template.yaml
+++ b/slides_template.yaml
@@ -1,0 +1,62 @@
+# スライド定義用テンプレート
+# 必要に応じて各プロパティを編集してください
+editableSlides:
+  - type: title
+    title: "タイトルを入力"
+    author: "発表者名"
+    date: "日付"
+    notes: "必要に応じて発表者ノートを書きます"
+
+  - type: list
+    header: "セクション見出し"
+    title: "リストスライドのタイトル"
+    content:
+      - text: "項目1"
+        fragment: true
+      - text: "項目2"
+    footerText: ""
+    notes: ""
+
+  - type: code
+    header: "セクション見出し"
+    title: "コード例"
+    subTitle: "説明"
+    text: "コードの説明文"
+    language: "python"
+    code: |
+      print("Hello World")
+    zoomable: true
+    footerText: ""
+    notes: ""
+
+  - type: pointCloud
+    header: "セクション見出し"
+    title: "点群データの例"
+    caption: "点群の説明"
+    points: 20000
+    zoomable: true
+    footerText: ""
+    notes: ""
+
+  - type: image
+    header: "セクション見出し"
+    title: "画像スライド"
+    imageSrc: "path/to/image.png"
+    caption: "画像の説明"
+    zoomable: true
+    footerText: ""
+    notes: ""
+
+  - type: video
+    header: "セクション見出し"
+    title: "動画スライド"
+    videoId: "YouTubeのID"
+    caption: "動画の説明"
+    zoomable: true
+    footerText: ""
+    notes: ""
+
+fixedSlides:
+  - type: end
+    title: "ご清聴ありがとうございました"
+    notes: ""


### PR DESCRIPTION
## Summary
- add `slides_template.yaml` with sample slide entries
- document slide types and usage in README

## Testing
- `python3 -m py_compile serve.py`
- `python3 - <<'PY'
import yaml
with open('slides_template.yaml') as f:
    yaml.safe_load(f)
print('OK')
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6880bdf7ff388327b0b0b31ee92115f0