### PR TITLE
Update speaker notes resize handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -349,6 +349,10 @@
                 timeElapsedEls.push(extElapsed);
                 timeCurrentEls.push(extCurrent);
 
+                externalNotesWindow.addEventListener('resize', () => {
+                    updateSpeakerNotes();
+                });
+
                 externalNotesWindow.addEventListener('beforeunload', () => {
                     notesContentEls.splice(notesContentEls.indexOf(extNotesContent), 1);
                     nextSlidePreviewEls.splice(nextSlidePreviewEls.indexOf(extNextPreview), 1);
@@ -470,6 +474,7 @@
 
                 window.addEventListener('resize', () => {
                     updatePresentationSize();
+                    updateSpeakerNotes();
                     Object.values(threeJSInstances).forEach(instance => {
                         if (instance && instance.camera && instance.renderer && instance.canvas) {
                             const { camera, renderer, canvas } = instance;


### PR DESCRIPTION
## Summary
- update the next slide preview when the browser window changes size
- ensure the external notes window rescales its preview on resize

## Testing
- `node --check main.js`
- `python3 -m py_compile serve.py`


------
https://chatgpt.com/codex/tasks/task_e_6880ca08c1dc83278cbd5bdb99533b1b