### PR TITLE
Enable slide controls from speaker notes

### DIFF
--- a/main.js
+++ b/main.js
@@ -360,6 +360,7 @@
                 const extReset = externalNotesWindow.document.getElementById('timer-reset-btn');
                 externalNotesWindow.document.getElementById('close-notes-btn').addEventListener('click', toggleSpeakerNotes);
                 if (extReset) extReset.addEventListener('click', resetTimer);
+                externalNotesWindow.document.addEventListener('keydown', handleKeyDown);
 
                 notesContentEls.push(extNotesContent);
                 nextSlidePreviewEls.push(extNextPreview);
@@ -375,6 +376,7 @@
                     nextSlidePreviewEls.splice(nextSlidePreviewEls.indexOf(extNextPreview), 1);
                     timeElapsedEls.splice(timeElapsedEls.indexOf(extElapsed), 1);
                     timeCurrentEls.splice(timeCurrentEls.indexOf(extCurrent), 1);
+                    externalNotesWindow.document.removeEventListener('keydown', handleKeyDown);
                     externalNotesWindow = null;
                 });
 
@@ -482,6 +484,31 @@
                 lightboxOverlay.classList.remove('is-visible');
                 lightboxContent.innerHTML = ''; // 3Dインスタンスなどを破棄
             }
+
+            function handleKeyDown(e) {
+                if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+                switch(e.key) {
+                    case 'ArrowRight':
+                    case ' ':
+                        next();
+                        break;
+                    case 'ArrowLeft':
+                        prev();
+                        break;
+                    case 'f':
+                        toggleFullscreen();
+                        break;
+                    case 'n':
+                        toggleSpeakerNotes();
+                        break;
+                    case 'l':
+                        toggleLaser();
+                        break;
+                    case 'Escape':
+                        closeLightbox();
+                        break;
+                }
+            }
             
             function init() {
                 generateSlides();
@@ -501,17 +528,7 @@
                 progressBarContainer.addEventListener('mousedown', progressDragStart);
                 progressBarContainer.addEventListener('touchstart', progressDragStart);
 
-                document.addEventListener('keydown', (e) => {
-                    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
-                    switch(e.key) {
-                        case 'ArrowRight': case ' ': next(); break;
-                        case 'ArrowLeft': prev(); break;
-                        case 'f': toggleFullscreen(); break;
-                        case 'n': toggleSpeakerNotes(); break;
-                        case 'l': toggleLaser(); break;
-                        case 'Escape': closeLightbox(); break;
-                    }
-                });
+                document.addEventListener('keydown', handleKeyDown);
 
                 document.addEventListener('mousemove', (e) => {
                     laserPointer.style.left = `${e.clientX}px`;


### PR DESCRIPTION
## Summary
- add a unified `handleKeyDown` handler
- hook the handler when the external speaker notes window opens
- use the new handler for key events

## Testing
- `python3 -m py_compile serve.py`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6880cce9f7248327b3647c7886fcf989