### PR TITLE
Add keyboard control in speaker notes

### DIFF
--- a/main.js
+++ b/main.js
@@ -342,6 +342,19 @@
                 });
             }
 
+            function handleKeyDown(e) {
+                if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+                switch (e.key) {
+                    case 'ArrowRight':
+                    case ' ': next(); break;
+                    case 'ArrowLeft': prev(); break;
+                    case 'f': toggleFullscreen(); break;
+                    case 'n': toggleSpeakerNotes(); break;
+                    case 'l': toggleLaser(); break;
+                    case 'Escape': closeLightbox(); break;
+                }
+            }
+
             function openExternalSpeakerNotes() {
                 if (externalNotesWindow && !externalNotesWindow.closed) {
                     externalNotesWindow.focus();
@@ -360,6 +373,7 @@
                 const extReset = externalNotesWindow.document.getElementById('timer-reset-btn');
                 externalNotesWindow.document.getElementById('close-notes-btn').addEventListener('click', toggleSpeakerNotes);
                 if (extReset) extReset.addEventListener('click', resetTimer);
+                externalNotesWindow.addEventListener('keydown', handleKeyDown);
 
                 notesContentEls.push(extNotesContent);
                 nextSlidePreviewEls.push(extNextPreview);
@@ -375,6 +389,7 @@
                     nextSlidePreviewEls.splice(nextSlidePreviewEls.indexOf(extNextPreview), 1);
                     timeElapsedEls.splice(timeElapsedEls.indexOf(extElapsed), 1);
                     timeCurrentEls.splice(timeCurrentEls.indexOf(extCurrent), 1);
+                    externalNotesWindow.removeEventListener('keydown', handleKeyDown);
                     externalNotesWindow = null;
                 });
 
@@ -501,17 +516,7 @@
                 progressBarContainer.addEventListener('mousedown', progressDragStart);
                 progressBarContainer.addEventListener('touchstart', progressDragStart);
 
-                document.addEventListener('keydown', (e) => {
-                    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
-                    switch(e.key) {
-                        case 'ArrowRight': case ' ': next(); break;
-                        case 'ArrowLeft': prev(); break;
-                        case 'f': toggleFullscreen(); break;
-                        case 'n': toggleSpeakerNotes(); break;
-                        case 'l': toggleLaser(); break;
-                        case 'Escape': closeLightbox(); break;
-                    }
-                });
+                document.addEventListener('keydown', handleKeyDown);
 
                 document.addEventListener('mousemove', (e) => {
                     laserPointer.style.left = `${e.clientX}px`;


### PR DESCRIPTION
## Summary
- support keyboard shortcuts in the speaker notes window so slides can move

## Testing
- `node -c main.js`

------
https://chatgpt.com/codex/tasks/task_e_6880cd02b8108327a07c651ccc29f97a