### PR TITLE
Remove fixedSlides section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ editableSlides:
 ```
 
 - `editableSlides` セクション内に表示したいスライドを順番に記述します。
-- `fixedSlides` セクションはテンプレートとして固定されており、通常は変更不要です。
+- 以前存在した `fixedSlides` セクションは廃止され、すべてのスライドを `editableSlides` に記述します。
 - スライドの種類（`type`）によって利用できるプロパティが異なります。
 - `defaultFooterText` を指定すると、各スライドで `footerText` を書かなくても共通のフッターを表示できます。
 

--- a/main.js
+++ b/main.js
@@ -615,7 +615,7 @@
                     .then(text => {
                         const yamlData = jsyaml.load(text);
                         defaultFooterText = yamlData.defaultFooterText || '';
-                        slideData = [...(yamlData.editableSlides || []), ...(yamlData.fixedSlides || [])];
+                        slideData = [...(yamlData.editableSlides || [])];
                         init();
                     })
                     .catch(err => {

--- a/slides.yaml
+++ b/slides.yaml
@@ -92,7 +92,6 @@ editableSlides:
     zoomable: true
     footerText: "Meta Presentation"
     notes: "オンライン動画の埋め込み例です。"
-fixedSlides:
   - type: list
     header: "5. 高度な機能"
     title: "発表者ツール"

--- a/slides_template.yaml
+++ b/slides_template.yaml
@@ -57,7 +57,6 @@ editableSlides:
     footerText: ""
     notes: ""
 
-fixedSlides:
   - type: end
     title: "ご清聴ありがとうございました"
     notes: ""


### PR DESCRIPTION
## Summary
- remove the unused `fixedSlides` section from the YAML data
- adjust JS loader to only read `editableSlides`
- drop mentions of `fixedSlides` in the docs

## Testing
- `python3 -m py_compile serve.py`
- `node -c main.js` *(fails: Identifier 'fontSize' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6880d3adcb108327a69533e1c81feef5