### PR TITLE
Fix duplicate fontSize const in JS

### DIFF
--- a/main.js
+++ b/main.js
@@ -58,9 +58,8 @@
                 const baseWidth = 1280; // design width used for styling
                 const scale = width / baseWidth;
                 const fontScale = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--font-scale')) || 1;
-                const fontSize = 16 * scale * fontScale;
                 // Slightly larger base font size for improved readability
-                const fontSize = 18 * scale;
+                const fontSize = 18 * scale * fontScale;
                 document.documentElement.style.fontSize = `${fontSize}px`;
             }
 


### PR DESCRIPTION
## Summary
- fix duplicate const in `main.js` that caused a syntax error

## Testing
- `node --check main.js`
- `python3 -m py_compile serve.py`

------
https://chatgpt.com/codex/tasks/task_e_6880d4bebf6883278e9f982986ab804b