### PR TITLE
Fix text clipping

### DIFF
--- a/style.css
+++ b/style.css
@@ -83,7 +83,7 @@
         .slide-content {
             flex-grow: 1;
             overflow-y: auto;
-            overflow-x: hidden;
+            overflow-x: visible;
             min-height: 0;
             display: flex;
             flex-direction: column;


### PR DESCRIPTION
## Summary
- fix text clipping on left side by removing horizontal overflow constraint

## Testing
- `python3 -m py_compile serve.py`

------
https://chatgpt.com/codex/tasks/task_e_6880d821285c8327aa2959d3bb567340