### PR TITLE
Fix navigation button alignment

### DIFF
--- a/main.js
+++ b/main.js
@@ -177,7 +177,7 @@
             }
 
             function updateControls() {
-                pageNumberEl.textContent = `${currentSlide + 1} / ${totalSlides}`;
+                pageNumberEl.textContent = `${currentSlide + 1}/${totalSlides}`;
                 const pageInfoEls = document.querySelectorAll('.page-info');
                 pageInfoEls.forEach(el => { el.textContent = `Page ${currentSlide + 1}`; });
                 const progressPercentage = totalSlides > 1 ? (currentSlide / (totalSlides - 1)) * 100 : 0;

--- a/style.css
+++ b/style.css
@@ -157,10 +157,34 @@
         /* --- ナビゲーション --- */
         #controls { margin-top: 25px; display: flex; flex-direction: column; align-items: center; gap: 15px; width: 100%; max-width: 800px; z-index: 1; }
         #navigation { display: flex; align-items: center; justify-content: center; gap: 10px; }
-        #controls button { background-color: rgba(255,255,255,0.1); color: var(--text-color); border: 1px solid var(--text-muted-color); padding: 10px 20px; font-family: 'Roboto', sans-serif; font-weight: 700; font-size: 0.9em; border-radius: 50px; cursor: pointer; transition: all 0.3s ease; min-width: 110px; text-align: center; }
+        #controls button {
+            background-color: rgba(255,255,255,0.1);
+            color: var(--text-color);
+            border: 1px solid var(--text-muted-color);
+            padding: 10px 20px;
+            font-family: 'Roboto', sans-serif;
+            font-weight: 700;
+            font-size: 0.9em;
+            border-radius: 50px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            min-width: 110px;
+            text-align: center;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            line-height: 1;
+        }
         #controls button:hover:not(:disabled) { background-color: var(--primary-color); color: var(--background-color); border-color: var(--primary-color); box-shadow: 0 0 15px var(--primary-color); }
         #controls button:disabled { border-color: #4a5568; color: #4a5568; cursor: not-allowed; background-color: transparent; }
-        #page-number { font-size: 1.2em; font-weight: 400; color: var(--text-muted-color); width: 80px; text-align: center; }
+        #page-number {
+            font-size: 1.2em;
+            font-weight: 400;
+            color: var(--text-muted-color);
+            width: 80px;
+            text-align: center;
+            white-space: nowrap;
+        }
         #progress-bar-container {
             width: 100%;
             height: 12px;


### PR DESCRIPTION
## Summary
- align bottom navigation buttons vertically with `inline-flex`
- keep page number on a single line and remove extra spaces

## Testing
- `python -m py_compile serve.py`

------
https://chatgpt.com/codex/tasks/task_e_6880d8ebb4008327aff4968b64fcd1ce