### PR TITLE
Fix speaker notes window style link

### DIFF
--- a/main.js
+++ b/main.js
@@ -390,7 +390,12 @@
                 externalNotesWindow = window.open('', 'speaker-notes', 'width=900,height=700');
                 if (!externalNotesWindow) return;
                 const notesHTML = notesWindow.outerHTML.replace('is-hidden', '');
-                externalNotesWindow.document.write(`<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"><title>Speaker Notes</title><link rel="stylesheet" href="style.css"></head><body>` + notesHTML + `</body></html>`);
+                const styleHref = new URL('style.css', window.location.href).href;
+                externalNotesWindow.document.write(
+                    `<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"><title>Speaker Notes</title><link rel="stylesheet" href="${styleHref}"></head><body>` +
+                    notesHTML +
+                    `</body></html>`
+                );
                 externalNotesWindow.document.close();
 
                 const extNotesContent = externalNotesWindow.document.getElementById('notes-content');


### PR DESCRIPTION
## Summary
- load CSS for the external speaker notes window using an absolute path

## Testing
- `python3 -m py_compile serve.py`

------
https://chatgpt.com/codex/tasks/task_e_6880eb02817c8327bb3efdfd37c0ae5f