### PR TITLE
Fix speaker notes next slide layout

### DIFF
--- a/main.js
+++ b/main.js
@@ -218,7 +218,9 @@
                         previewNode.classList.remove('is-active', 'is-exiting');
                         previewNode.style.opacity = '1';
                         previewNode.style.transform = 'none';
-                        previewNode.style.position = 'relative';
+                        // Keep the cloned slide absolutely positioned so the
+                        // preview does not expand the sidebar layout
+                        previewNode.style.position = 'absolute';
                         previewNode.style.pointerEvents = 'none';
                         previewNode.querySelectorAll('.fragment').forEach(f => f.classList.add('is-visible'));
 

--- a/style.css
+++ b/style.css
@@ -255,7 +255,9 @@
         #timer-reset-btn { background-color: rgba(255,255,255,0.1); color: var(--text-color); border: 1px solid var(--text-muted-color); padding: 6px 12px; font-family: 'Roboto', sans-serif; font-weight: 700; font-size: 0.8em; border-radius: 50px; cursor: pointer; transition: all 0.3s ease; align-self: center; }
         #timer-reset-btn:hover { background-color: var(--primary-color); color: var(--background-color); border-color: var(--primary-color); box-shadow: 0 0 15px var(--primary-color); }
         #next-slide-preview {
-            flex-grow: 1;
+            flex-grow: 0;
+            width: 100%;
+            height: auto;
             border: 1px solid var(--border-color);
             border-radius: 8px;
             background: var(--background-color);


### PR DESCRIPTION
## Summary
- keep cloned slide absolutely positioned to avoid expanding sidebar layout
- restrict next slide preview width in CSS

## Testing
- `python3 -m py_compile serve.py`

------
https://chatgpt.com/codex/tasks/task_e_6880ed1d3edc832799bb992d5f11c314