### PR TITLE
Add custom YAML loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-./Slide/
+Slide/

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ editableSlides:
 - スライドの種類（`type`）によって利用できるプロパティが異なります。
 - `defaultFooterText` を指定すると、各スライドで `footerText` を書かなくても共通のフッターを表示できます。
 
+### 独自の YAML ファイルを使用する
+
+`Slide/` ディレクトリにプレゼン用の YAML ファイルを置くと、`.gitignore` により Git の管理対象外となります。読み込むファイルは `yaml` クエリパラメータで指定できます。
+
+```bash
+http://localhost:8000/index.html?yaml=Slide/my_presentation.yaml
+```
+
+パラメータを省略した場合は既定の `slides.yaml` が読み込まれます。
+
 ## スライドテンプレートの利用方法
 
 本リポジトリには `slides_template.yaml` を同梱しています。新しいプレゼンテーションを作成する際はこのファイルをコピーし、内容を編集して `slides.yaml` として保存してください。

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
         <div id="lightbox-content"></div>
     </div>
     <div id="file-inputs" style="display: none;"></div>
-    <!-- ▼▼▼ スライドの内容は slides.yaml から読み込まれます ▼▼▼ -->
+    <!-- ▼▼▼ スライドの内容は slides.yaml または URL の ?yaml= で指定したファイルから読み込まれます ▼▼▼ -->
     <!-- ▲▲▲ スライドの内容はここまで ▲▲▲ -->
 
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -688,7 +688,9 @@
                 startTimers();
             }
 
-                fetch("slides.yaml")
+                const params = new URLSearchParams(window.location.search);
+                const yamlFile = params.get('yaml') || params.get('slides') || 'slides.yaml';
+                fetch(yamlFile)
                     .then(res => res.text())
                     .then(text => {
                         const yamlData = jsyaml.load(text);
@@ -700,7 +702,7 @@
                         init();
                     })
                     .catch(err => {
-                        console.error("failed to load slides.yaml", err);
+                        console.error(`failed to load ${yamlFile}`, err);
                         init();
                     });
         });


### PR DESCRIPTION
## Summary
- ignore `Slide/` directory for local presentations
- allow specifying YAML file via `?yaml=` query parameter
- document how to use custom YAML files
- clarify comment in `index.html`

## Testing
- `python3 -m py_compile serve.py`

------
https://chatgpt.com/codex/tasks/task_e_6880f090cabc83278dffc4dd34715610