### PR TITLE
Add ordered list option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ editableSlides:
 - `date`: 日付
 
 **list**
+- `ordered`: `true` で番号付きリスト、`false` でドットの箇条書き (省略時は `true`)
 - `content`: リスト項目の配列。要素は文字列、または以下を含むオブジェクトを指定できます。
   - `text`: 表示する文字列
   - `fragment`: `true` にすると項目を順に表示

--- a/main.js
+++ b/main.js
@@ -96,8 +96,9 @@
                             contentHTML = `<div class="title-slide"><h1>${data.title}</h1><p class="author">${data.author}</p><p class="date">${data.date}</p></div>`;
                             break;
                         case 'list':
+                            const listTag = data.ordered === false ? 'ul' : 'ol';
                             const listItems = data.content.map(item => `<li ${item.jumpTo ? `data-jump-to="${item.jumpTo}"` : ''} class="${item.fragment ? 'fragment' : ''}">${item.text || item}</li>`).join('');
-                            contentHTML = `<header class="slide-header">${data.header}</header><h2>${data.title}</h2><div class="slide-content"><ol>${listItems}</ol></div><footer class="slide-footer"><span>${footer}</span><span class="page-info"></span></footer>`;
+                            contentHTML = `<header class="slide-header">${data.header}</header><h2>${data.title}</h2><div class="slide-content"><${listTag}>${listItems}</${listTag}></div><footer class="slide-footer"><span>${footer}</span><span class="page-info"></span></footer>`;
                             break;
                         case 'code':
                              contentHTML = `<header class="slide-header">${data.header}</header><h2>${data.title}</h2><div class="slide-content three-column"><div class="column"><h3>${data.subTitle}</h3><p>${data.text}</p></div><div class="column"><pre><code class="language-${data.language || 'plaintext'}">${data.code.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</code></pre></div></div><footer class="slide-footer"><span>${footer}</span><span class="page-info"></span></footer>`;

--- a/slides.yaml
+++ b/slides.yaml
@@ -91,6 +91,7 @@ editableSlides:
   - type: list
     header: "5. 高度な機能"
     title: "発表者ツール"
+    ordered: false
     content:
       - "<strong>URLハッシュ同期:</strong> スライドを移動すると、ブラウザのURLが自動的に更新されます (例: <code>#slide=3</code>)。このURLを共有すれば、誰でも同じスライドから閲覧を開始できます。"
       - "<strong>レーザーポインター:</strong> キーボードの『L』キーを押すと、仮想レーザーポインターが有効になります。発表中に特定の部分を指し示すのに便利です。"

--- a/slides_template.yaml
+++ b/slides_template.yaml
@@ -12,6 +12,7 @@ editableSlides:
   - type: list
     header: "セクション見出し"
     title: "リストスライドのタイトル"
+    ordered: true  # true: 数字のリスト、false: ドットのリスト
     content:
       - text: "項目1"
         fragment: true

--- a/style.css
+++ b/style.css
@@ -124,14 +124,17 @@
             text-align: left;
             width: 100%;
         }
-        .slide-content ol {
+        .slide-content ol,
+        .slide-content ul {
             text-align: left;
             margin: 0;
             padding-left: 1.2em;
             list-style-position: inside;
         }
-        .slide-content ol li { cursor: pointer; transition: color 0.3s; }
-        .slide-content ol li:hover { color: var(--primary-color); }
+        .slide-content ol li,
+        .slide-content ul li { cursor: pointer; transition: color 0.3s; }
+        .slide-content ol li:hover,
+        .slide-content ul li:hover { color: var(--primary-color); }
 
         /* --- 各スライドのレイアウト調整 --- */
         .title-slide { justify-content: center; align-items: flex-start; text-align: left; }


### PR DESCRIPTION
## Summary
- support bullet or numbered lists per slide via `ordered` flag
- document the `ordered` option
- show an example bullet list in slides
- update list rendering logic
- style `<ul>` the same as `<ol>`

## Testing
- `python3 -m py_compile serve.py`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6880fa407cac8327bb059f86e8b68abc