### PR TITLE
Update README with list content rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ editableSlides:
   - `text`: 表示する文字列
   - `fragment`: `true` にすると項目を順に表示
   - `jumpTo`: クリックしたときに移動するスライド番号
+- `content` は必須で、項目がない場合でも空の配列 `[]` を指定してください。
 
 **code**
 - `subTitle`: コードに付随する小見出し


### PR DESCRIPTION
## Summary
- clarify that `content` is mandatory for `list` slides

## Testing
- `python3 -m py_compile serve.py`


------
https://chatgpt.com/codex/tasks/task_e_6881001ed7ec8327b5bac725cdcc8ddf