### PR TITLE
Improve slide performance

### DIFF
--- a/main.js
+++ b/main.js
@@ -296,7 +296,7 @@
                     }
                 }
 
-                const material = new THREE.PointsMaterial({ size: 0.015, vertexColors: useVertexColors });
+                const material = new THREE.PointsMaterial({ size: 0.012, vertexColors: useVertexColors });
                 if (!useVertexColors) {
                     material.color.set(0x00bfff);
                 }
@@ -321,7 +321,7 @@
                 let animationId;
                 function animate() {
                     animationId = requestAnimationFrame(animate);
-                    points.rotation.y += 0.0005;
+                    points.rotation.y += 0.0002;
                     controls.update();
                     renderer.render(scene, camera);
                 }

--- a/slides.yaml
+++ b/slides.yaml
@@ -66,7 +66,7 @@ editableSlides:
     header: "4. 拡張機能"
     title: "インタラクティブな3D点群データ"
     caption: "three.js を利用して3Dデータを描画しています。マウスでドラッグしてモデルを回転できます。"
-    points: 20000
+    points: 10000
     notes: "three.jsとOrbitControlsを統合したデモです。球状の点群データを生成しています。"
   - type: pointCloud
     header: "4. 拡張機能"

--- a/style.css
+++ b/style.css
@@ -89,7 +89,7 @@
         #presentation { width: 100%; height: 100%; position: relative; transform-style: preserve-3d; }
 
         /* --- 各スライドの基本スタイル (深度スライド) --- */
-        .slide { width: 100%; height: 100%; position: absolute; top: 0; left: 0; padding: 4% 5%; box-sizing: border-box; display: flex; flex-direction: column; justify-content: center; align-items: flex-start; text-align: left; border-radius: 16px; background: var(--surface-color); border: 1px solid var(--border-color); box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4); backdrop-filter: blur(24px); opacity: 0; transform: translateZ(-200px) scale(0.9); transition: transform 0.8s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1), background-color 0.5s, border-color 0.5s; pointer-events: none; }
+        .slide { width: 100%; height: 100%; position: absolute; top: 0; left: 0; padding: 4% 5%; box-sizing: border-box; display: flex; flex-direction: column; justify-content: center; align-items: flex-start; text-align: left; border-radius: 16px; background: var(--surface-color); border: 1px solid var(--border-color); box-shadow: 0 12px 36px rgba(0, 0, 0, 0.3); backdrop-filter: blur(16px); opacity: 0; transform: translateZ(-200px) scale(0.9); transition: transform 0.8s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1), background-color 0.5s, border-color 0.5s; pointer-events: none; }
         .slide.is-active { opacity: 1; transform: translateZ(0) scale(1); pointer-events: auto; }
         .slide.is-exiting { opacity: 0; transform: translateZ(200px) scale(1.1); pointer-events: none; }
 


### PR DESCRIPTION
## Summary
- lighten point cloud example by reducing default points
- slow down rotation and shrink point size
- reduce blur and shadow for slide backgrounds

## Testing
- `python3 -m py_compile serve.py`
- `python3 serve.py --help | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6881024a4ef083279ec1543559937162