### PR TITLE
Add slide type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ http://localhost:8000/index.html?yaml=Slide/my_presentation.yaml
 
 各型のプロパティは必要に応じて追加できます。詳しくは `slides_template.yaml` のコメントを参考にしてください。
 
+### 型定義ファイル
+
+スライドデータの構造を厳密に扱いたい場合は、TypeScript 用の `slideTypes.ts` と
+JSON スキーマ `slides.schema.json` を利用できます。IDE の補完や検証に役立ちます。
+
 ### ローカルファイルの利用
 
 `image`、`video`、`pointCloud` の各スライドでは `fileInputId` プロパティを指定することで、

--- a/slideTypes.ts
+++ b/slideTypes.ts
@@ -1,0 +1,107 @@
+// TypeScript definitions for slide data structures
+
+/** Base properties shared by all slide types */
+interface BaseSlide {
+    /** Slide type identifier */
+    type: string;
+    /** Optional section header */
+    header?: string;
+    /** Slide title */
+    title: string;
+    /** Optional footer override */
+    footerText?: string;
+    /** Presenter notes (HTML allowed) */
+    notes?: string;
+    /** ID of <input type="file"> for local file loading */
+    fileInputId?: string;
+    /** Allow zooming on click */
+    zoomable?: boolean;
+}
+
+/** Individual item used within a list slide */
+interface ListItem {
+    /** Text content of the item */
+    text: string;
+    /** Reveal item incrementally */
+    fragment?: boolean;
+    /** Slide index to jump to when clicked */
+    jumpTo?: number;
+}
+
+/** Title slide */
+interface TitleSlide extends BaseSlide {
+    type: 'title';
+    author: string;
+    date?: string;
+}
+
+/** Bullet or numbered list slide */
+interface ListSlide extends BaseSlide {
+    type: 'list';
+    /** true for numbered list, false for bullet list */
+    ordered?: boolean;
+    /** Array of list items. Can be empty but must exist. */
+    content: ListItem[];
+}
+
+/** Code sample slide */
+interface CodeSlide extends BaseSlide {
+    type: 'code';
+    subTitle?: string;
+    text?: string;
+    language?: string;
+    code: string;
+}
+
+/** Image slide */
+interface ImageSlide extends BaseSlide {
+    type: 'image';
+    imageSrc?: string;
+    caption?: string;
+    math?: string;
+}
+
+/** Video or local movie slide */
+interface VideoSlide extends BaseSlide {
+    type: 'video';
+    /** YouTube video ID. If absent, local file playback is used. */
+    videoId?: string;
+    caption?: string;
+}
+
+/** Point cloud slide rendered via three.js */
+interface PointCloudSlide extends BaseSlide {
+    type: 'pointCloud';
+    /** Number of random points when no file is provided */
+    points?: number;
+    /** Use r,g,b values included in the file */
+    useVertexColors?: boolean;
+    caption?: string;
+    /** Populated when loading a file */
+    pointData?: {
+        vertices: number[];
+        colors: number[];
+    };
+}
+
+/** Final slide */
+interface EndSlide extends BaseSlide {
+    type: 'end';
+}
+
+/** Union type of all possible slides */
+export type Slide =
+    | TitleSlide
+    | ListSlide
+    | CodeSlide
+    | ImageSlide
+    | VideoSlide
+    | PointCloudSlide
+    | EndSlide;
+
+/** YAML root object structure */
+export interface SlideDeck {
+    defaultFooterText?: string;
+    fontScale?: number;
+    editableSlides: Slide[];
+}

--- a/slides.schema.json
+++ b/slides.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SlideDeck",
+  "type": "object",
+  "properties": {
+    "defaultFooterText": { "type": "string" },
+    "fontScale": { "type": "number" },
+    "editableSlides": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/slide" }
+    }
+  },
+  "required": ["editableSlides"],
+  "definitions": {
+    "base": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string" },
+        "header": { "type": "string" },
+        "title": { "type": "string" },
+        "footerText": { "type": "string" },
+        "notes": { "type": "string" },
+        "fileInputId": { "type": "string" },
+        "zoomable": { "type": "boolean" }
+      },
+      "required": ["type", "title"],
+      "additionalProperties": true
+    },
+    "titleSlide": {
+      "allOf": [
+        { "$ref": "#/definitions/base" },
+        {
+          "properties": {
+            "type": { "const": "title" },
+            "author": { "type": "string" },
+            "date": { "type": "string" }
+          },
+          "required": ["author"]
+        }
+      ]
+    },
+    "listItem": {
+      "type": "object",
+      "properties": {
+        "text": { "type": "string" },
+        "fragment": { "type": "boolean" },
+        "jumpTo": { "type": "integer" }
+      },
+      "required": ["text"],
+      "additionalProperties": false
+    },
+    "listSlide": {
+      "allOf": [
+        { "$ref": "#/definitions/base" },
+        {
+          "properties": {
+            "type": { "const": "list" },
+            "ordered": { "type": "boolean" },
+            "content": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/listItem" }
+            }
+          },
+          "required": ["content"]
+        }
+      ]
+    },
+    "codeSlide": {
+      "allOf": [
+        { "$ref": "#/definitions/base" },
+        {
+          "properties": {
+            "type": { "const": "code" },
+            "subTitle": { "type": "string" },
+            "text": { "type": "string" },
+            "language": { "type": "string" },
+            "code": { "type": "string" }
+          },
+          "required": ["code"]
+        }
+      ]
+    },
+    "imageSlide": {
+      "allOf": [
+        { "$ref": "#/definitions/base" },
+        {
+          "properties": {
+            "type": { "const": "image" },
+            "imageSrc": { "type": "string" },
+            "caption": { "type": "string" },
+            "math": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "videoSlide": {
+      "allOf": [
+        { "$ref": "#/definitions/base" },
+        {
+          "properties": {
+            "type": { "const": "video" },
+            "videoId": { "type": "string" },
+            "caption": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "pointCloudSlide": {
+      "allOf": [
+        { "$ref": "#/definitions/base" },
+        {
+          "properties": {
+            "type": { "const": "pointCloud" },
+            "points": { "type": "integer" },
+            "useVertexColors": { "type": "boolean" },
+            "caption": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "endSlide": {
+      "allOf": [
+        { "$ref": "#/definitions/base" },
+        { "properties": { "type": { "const": "end" } } }
+      ]
+    },
+    "slide": {
+      "oneOf": [
+        { "$ref": "#/definitions/titleSlide" },
+        { "$ref": "#/definitions/listSlide" },
+        { "$ref": "#/definitions/codeSlide" },
+        { "$ref": "#/definitions/imageSlide" },
+        { "$ref": "#/definitions/videoSlide" },
+        { "$ref": "#/definitions/pointCloudSlide" },
+        { "$ref": "#/definitions/endSlide" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- document slide schema in JSON and TypeScript
- note the new type files in the README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6881027980e083279d7aba3c2027894e