### PR TITLE
Add quote slide layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ http://localhost:8000/index.html?yaml=Slide/my_presentation.yaml
 | `pointCloud` | `header`, `title`, `points`, `fileInputId` | 点群データを three.js で描画します |
 | `image` | `header`, `title`, `imageSrc`, `fileInputId` | 画像の表示用スライド |
 | `video` | `header`, `title`, `videoId`, `fileInputId` | YouTube もしくはローカル動画を再生します |
+| `quote` | `quote`, `author` | 引用文を大きく表示するスライド |
 | `end` | `title` | 終了画面 |
 
 各型のプロパティは必要に応じて追加できます。詳しくは `slides_template.yaml` のコメントを参考にしてください。
@@ -137,7 +138,7 @@ editableSlides:
 
 #### スライド共通プロパティ
 
-- **type**: スライドの種類 (`title`, `list`, `code`, `image`, `video`, `pointCloud`, `end` のいずれか)。
+ - **type**: スライドの種類 (`title`, `list`, `code`, `image`, `video`, `pointCloud`, `quote`, `end` のいずれか)。
 - **header**: 任意のセクション見出し。
 - **title**: スライドタイトル。
 - **footerText**: 個別のフッター文字列。未指定なら `defaultFooterText` が使用されます。
@@ -185,6 +186,10 @@ editableSlides:
 - `useVertexColors`: `true` のとき r,g,b を含む点群ファイルをカラー表示
 - `caption`: 点群の説明文
 - `zoomable`: 点群表示を拡大するか
+
+**quote**
+- `quote`: 表示する引用文
+- `author`: 引用元の名前
 
 **end**
 - 特別なプロパティはありません。`title` のみを指定します。

--- a/main.js
+++ b/main.js
@@ -110,6 +110,9 @@
                              let videoSrc = data.videoId ? `https://www.youtube.com/embed/${data.videoId}` : '';
                              contentHTML = `<header class="slide-header">${data.header}</header><h2>${data.title}</h2><div class="slide-content"><div class="video-slide-content"><${data.videoId ? 'iframe' : 'video'} src="${videoSrc}" ${data.fileInputId ? `data-file-input-id="${data.fileInputId}"` : ''} ${!data.videoId ? 'controls' : ''} frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></${data.videoId ? 'iframe' : 'video'}></div><p>${data.caption || ''}</p></div><footer class="slide-footer"><span>${footer}</span><span class="page-info"></span></footer>`;
                             break;
+                        case 'quote':
+                             contentHTML = `<div class="quote-slide"><blockquote>${data.quote}</blockquote><p class="quote-author">${data.author || ''}</p></div>`;
+                             break;
                         case 'pointCloud':
                             contentHTML = `<header class="slide-header">${data.header}</header><h2>${data.title}</h2><div class="slide-content point-cloud-container" data-slide-index="${index}"><canvas class="point-cloud-canvas" data-points="${data.points || 0}" data-use-vertex-colors="${data.useVertexColors || false}" ${data.fileInputId ? `data-file-input-id="${data.fileInputId}"` : ''}></canvas></div><p style="text-align: center;">${data.caption}</p><footer class="slide-footer"><span>${footer}</span><span class="page-info"></span></footer>`;
                             break;

--- a/slides.yaml
+++ b/slides.yaml
@@ -88,6 +88,11 @@ editableSlides:
     caption: "YouTubeから動画を直接再生します。"
     footerText: "Meta Presentation"
     notes: "オンライン動画の埋め込み例です。"
+  - type: quote
+    quote: "The nice thing about standards is that there are so many to choose from."
+    author: "Andrew S. Tanenbaum"
+    notes: "引用例として表示します。"
+
   - type: list
     header: "5. 高度な機能"
     title: "発表者ツール"

--- a/slides_template.yaml
+++ b/slides_template.yaml
@@ -55,6 +55,11 @@ editableSlides:
     footerText: ""
     notes: ""
 
+  - type: quote
+    quote: "引用文をここに"
+    author: "引用元"
+    notes: ""
+
   - type: end
     title: "ご清聴ありがとうございました"
     notes: ""

--- a/style.css
+++ b/style.css
@@ -194,6 +194,26 @@
     box-shadow: 0 10px 30px rgba(0,0,0,0.3);
     border: none;
 }
+.quote-slide {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+.quote-slide blockquote {
+    font-size: 1.8em;
+    font-style: italic;
+    margin: 0 auto;
+    max-width: 80%;
+}
+.quote-slide .quote-author {
+    margin-top: 20px;
+    font-size: 1.2em;
+    color: var(--text-muted-color);
+    width: 80%;
+    text-align: right;
+}
         .point-cloud-container { flex-grow: 1; position: relative; }
         .point-cloud-canvas { width: 100%; height: 100%; display: block; cursor: grab; }
 


### PR DESCRIPTION
## Summary
- add `quote` layout type to presentation engine
- update default template and example slides
- style quote slides and document new type

## Testing
- `python3 -m py_compile serve.py`
- `python3 - <<'PY'
import yaml
yaml.safe_load(open('slides.yaml'))
yaml.safe_load(open('slides_template.yaml'))
print('YAML OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_688102b96a6883278d9e25bd9833eb5b