### PR TITLE
Adjust video and point cloud embed sizes

### DIFF
--- a/style.css
+++ b/style.css
@@ -178,8 +178,8 @@
 }
 .video-slide-content {
     flex-grow: 1;
-    max-width: 80%;
-    max-height: 60vh;
+    max-width: 70%;
+    max-height: 50vh;
     margin: 0 auto;
     width: 100%;
 }
@@ -194,7 +194,14 @@
     box-shadow: 0 10px 30px rgba(0,0,0,0.3);
     border: none;
 }
-        .point-cloud-container { flex-grow: 1; position: relative; }
+        .point-cloud-container {
+            flex-grow: 1;
+            position: relative;
+            max-width: 70%;
+            max-height: 50vh;
+            margin: 0 auto;
+            width: 100%;
+        }
         .point-cloud-canvas { width: 100%; height: 100%; display: block; cursor: grab; }
 
         /* --- ヘッダーとフッター --- */


### PR DESCRIPTION
## Summary
- shrink the default video area
- limit point cloud display size similar to videos

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68810e65e82c8327ae64353440b3f65b