### PR TITLE
Scale slides proportionally on window resize

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,40 +42,40 @@
             let lastPresentationWidth = 0;
             let lastPresentationHeight = 0;
             let lastRootFontSize = 0;
+            let lastScale = 1;
 
             function updatePresentationSize() {
                 const wrapper = document.getElementById('presentation-wrapper');
+                const presentation = document.getElementById('presentation');
 
                 if (document.fullscreenElement && lastPresentationWidth && lastPresentationHeight && lastRootFontSize) {
                     wrapper.style.width = `${lastPresentationWidth}px`;
                     wrapper.style.height = `${lastPresentationHeight}px`;
+                    presentation.style.setProperty('--presentation-scale', lastScale);
                     document.documentElement.style.fontSize = `${lastRootFontSize}px`;
                     return;
                 }
 
+                const baseWidth = 1280;
+                const baseHeight = 720;
                 const maxWidth = window.innerWidth * 0.9;
                 const maxHeight = window.innerHeight * 0.9;
-                let width = maxWidth;
-                let height = width * 9 / 16;
-                if (height > maxHeight) {
-                    height = maxHeight;
-                    width = height * 16 / 9;
-                }
+                const scale = Math.min(maxWidth / baseWidth, maxHeight / baseHeight);
+
+                const width = baseWidth * scale;
+                const height = baseHeight * scale;
                 wrapper.style.width = `${width}px`;
                 wrapper.style.height = `${height}px`;
+                presentation.style.setProperty('--presentation-scale', scale);
 
-                // Scale base font size relative to the presentation width so
-                // that text scales proportionally with the window size.
-                const baseWidth = 1280; // design width used for styling
-                const scale = width / baseWidth;
                 const fontScale = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--font-scale')) || 1;
-                // Slightly larger base font size for improved readability
                 const fontSize = 18 * scale * fontScale;
                 document.documentElement.style.fontSize = `${fontSize}px`;
 
                 lastPresentationWidth = width;
                 lastPresentationHeight = height;
                 lastRootFontSize = fontSize;
+                lastScale = scale;
             }
 
             function generateSlides() {

--- a/style.css
+++ b/style.css
@@ -85,8 +85,8 @@
         @keyframes move-aurora-2 { from { transform: translate(0, 0) rotate(0deg); } to { transform: translate(-300px, -150px) rotate(-120deg); } }
 
         /* --- プレゼンテーションコンテナ --- */
-        #presentation-wrapper { width: 90vw; height: min(calc(90vw * 9 / 16), calc(100vh - 180px)); max-width: 1280px; max-height: calc(100vh - 180px); position: relative; z-index: 1; perspective: 1500px; cursor: default; }
-        #presentation { width: 100%; height: 100%; position: relative; transform-style: preserve-3d; }
+        #presentation-wrapper { position: relative; z-index: 1; perspective: 1500px; cursor: default; }
+        #presentation { width: 1280px; height: 720px; position: relative; transform-style: preserve-3d; transform-origin: top left; transform: scale(var(--presentation-scale, 1)); }
 
         /* --- 各スライドの基本スタイル (深度スライド) --- */
         .slide { width: 100%; height: 100%; position: absolute; top: 0; left: 0; padding: 4% 5%; box-sizing: border-box; display: flex; flex-direction: column; justify-content: center; align-items: flex-start; text-align: left; border-radius: 16px; background: var(--surface-color); border: 1px solid var(--border-color); box-shadow: 0 12px 36px rgba(0, 0, 0, 0.3); backdrop-filter: blur(16px); opacity: 0; transform: translateZ(-200px) scale(0.9); transition: transform 0.8s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1), background-color 0.5s, border-color 0.5s; pointer-events: none; }


### PR DESCRIPTION
## Summary
- keep presentation wrapper simple so JS controls its size
- scale the entire presentation via `--presentation-scale`
- adjust JS to compute scale and apply via CSS variable

## Testing
- `python -m py_compile serve.py`


------
https://chatgpt.com/codex/tasks/task_e_68810f09e45c8327afeed1435cb66f59