### PR TITLE
Add image list option and expand media layout

### DIFF
--- a/main.js
+++ b/main.js
@@ -104,7 +104,12 @@
                              contentHTML = `<header class="slide-header">${data.header}</header><h2>${data.title}</h2><div class="slide-content three-column"><div class="column"><h3>${data.subTitle}</h3><p>${data.text}</p></div><div class="column"><pre><code class="language-${data.language || 'plaintext'}">${data.code.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</code></pre></div></div><footer class="slide-footer"><span>${footer}</span><span class="page-info"></span></footer>`;
                             break;
                         case 'image':
-                             contentHTML = `<header class="slide-header">${data.header}</header><h2>${data.title}</h2><div class="slide-content"><div class="image-slide-content"><img src="${data.imageSrc || ''}" alt="${data.title}" ${data.fileInputId ? `data-file-input-id="${data.fileInputId}"` : ''}></div><p>${data.caption || ''}</p><div>${data.math || ''}</div></div><footer class="slide-footer"><span>${footer}</span><span class="page-info"></span></footer>`;
+                             if (data.listContent && data.listContent.length) {
+                                const listItemsImg = data.listContent.map(item => `<li ${item.jumpTo ? `data-jump-to="${item.jumpTo}"` : ''} class="${item.fragment ? 'fragment' : ''}">${item.text || item}</li>`).join('');
+                                contentHTML = `<header class="slide-header">${data.header}</header><h2>${data.title}</h2><div class="slide-content two-column"><div class="column"><div class="image-slide-content"><img src="${data.imageSrc || ''}" alt="${data.title}" ${data.fileInputId ? `data-file-input-id="${data.fileInputId}"` : ''}></div><p>${data.caption || ''}</p></div><div class="column"><ul>${listItemsImg}</ul></div></div><footer class="slide-footer"><span>${footer}</span><span class="page-info"></span></footer>`;
+                             } else {
+                                contentHTML = `<header class="slide-header">${data.header}</header><h2>${data.title}</h2><div class="slide-content"><div class="image-slide-content"><img src="${data.imageSrc || ''}" alt="${data.title}" ${data.fileInputId ? `data-file-input-id="${data.fileInputId}"` : ''}></div><p>${data.caption || ''}</p><div>${data.math || ''}</div></div><footer class="slide-footer"><span>${footer}</span><span class="page-info"></span></footer>`;
+                             }
                             break;
                         case 'video':
                              const isYouTube = !!data.videoId && !data.videoSrc;
@@ -118,7 +123,7 @@
                             contentHTML = `<div class="end-slide"><h1>${data.title}</h1></div>`;
                             break;
                     }
-                    slideHTML += `<div class="slide" data-index="${index}">${contentHTML}</div>`;
+                    slideHTML += `<div class="slide ${data.type}-slide" data-index="${index}">${contentHTML}</div>`;
                 });
 
                 presentation.innerHTML = slideHTML;

--- a/slideTypes.ts
+++ b/slideTypes.ts
@@ -59,6 +59,7 @@ interface ImageSlide extends BaseSlide {
     imageSrc?: string;
     caption?: string;
     math?: string;
+    listContent?: ListItem[];
 }
 
 /** Video or local movie slide */

--- a/slides.schema.json
+++ b/slides.schema.json
@@ -88,7 +88,11 @@
             "type": { "const": "image" },
             "imageSrc": { "type": "string" },
             "caption": { "type": "string" },
-            "math": { "type": "string" }
+            "math": { "type": "string" },
+            "listContent": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/listItem" }
+            }
           }
         }
       ]

--- a/slides.yaml
+++ b/slides.yaml
@@ -77,6 +77,9 @@ editableSlides:
     title: "ローカル画像の読み込み"
     fileInputId: "local-image"
     caption: "ローカルから画像ファイルを読み込んで表示します。"
+    listContent:
+      - text: "画像を選択すると即座に表示"
+      - text: "複数形式に対応"
     notes: "画像ファイルを選択してください。"
   - type: video
     header: "4. 拡張機能"

--- a/slides_template.yaml
+++ b/slides_template.yaml
@@ -46,6 +46,10 @@ editableSlides:
     title: "画像スライド"
     imageSrc: "path/to/image.png"
     caption: "画像の説明"
+    # 箇条書きを併記したい場合は listContent を指定します
+    listContent:
+      - text: "ポイント1"
+      - text: "ポイント2"
     footerText: ""
     notes: ""
 

--- a/style.css
+++ b/style.css
@@ -142,7 +142,12 @@
         .title-slide .author { font-size: 1.5em; color: var(--text-color); margin-top: 24px; }
         .title-slide .date { font-size: 1.2em; color: var(--text-muted-color); margin-top: 12px; }
 .three-column { display: flex; gap: 30px; width: 100%; height: 100%; }
+.two-column { display: flex; gap: 30px; width: 100%; height: 100%; }
 .column { flex: 1; overflow: hidden; }
+.slide.video-slide,
+.slide.pointCloud-slide { justify-content: flex-start; }
+.slide.video-slide .slide-content,
+.slide.pointCloud-slide .slide-content { flex-grow: 1; width: 100%; }
 .column h3 { font-size: 1.3em; }
 .column p { font-size: 1.3em; }
 .three-column .column:last-child {
@@ -178,15 +183,16 @@
 }
 .video-slide-content {
     flex-grow: 1;
-    max-width: 70%;
-    max-height: 50vh;
+    max-width: 100%;
+    max-height: none;
     margin: 0 auto;
     width: 100%;
+    height: 100%;
 }
 .video-slide-content iframe,
 .video-slide-content video {
     width: 100%;
-    height: auto;
+    height: 100%;
     max-width: 100%;
     max-height: 100%;
     aspect-ratio: 16 / 9;
@@ -197,10 +203,11 @@
         .point-cloud-container {
             flex-grow: 1;
             position: relative;
-            max-width: 70%;
-            max-height: 50vh;
+            max-width: 100%;
+            max-height: none;
             margin: 0 auto;
             width: 100%;
+            height: 100%;
         }
         .point-cloud-canvas { width: 100%; height: 100%; display: block; cursor: grab; }
 


### PR DESCRIPTION
## Summary
- allow image slides to include a bullet list via `listContent`
- render slide container with type-specific class
- enlarge video and point cloud display area
- update schema and slide templates

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_688110bed32c8327b8e371df710d34d9