### PR TITLE
Add vertex color point cloud support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ http://localhost:8000/index.html?yaml=Slide/my_presentation.yaml
 
 - type: pointCloud
   pointCloudSrc: "data/points.txt"
+  # RGB 値が含まれるファイルでは useVertexColors: true を指定します
+  # useVertexColors: true
 ```
 
 パスは `index.html` からの相対パスで記述してください。
@@ -120,7 +122,7 @@ http://localhost:8000/index.html?yaml=Slide/my_presentation.yaml
 | `title` | `title`, `author`, `date`, `notes` | タイトルスライド |
 | `list` | `header`, `title`, `content`, `footerText` | 箇条書きのスライド。`content` 配下に `text` などを記入します |
 | `code` | `header`, `title`, `language`, `code` | ソースコードを表示します |
-| `pointCloud` | `header`, `title`, `points`, `pointCloudSrc`, `fileInputId` | 点群データを three.js で描画します |
+| `pointCloud` | `header`, `title`, `points`, `pointCloudSrc`, `fileInputId`, `useVertexColors` | 点群データを three.js で描画します |
 | `image` | `header`, `title`, `imageSrc`, `fileInputId` | 画像の表示用スライド |
 | `video` | `header`, `title`, `videoId`, `videoSrc`, `fileInputId` | YouTube もしくはローカル動画を再生します |
 | `end` | `title` | 終了画面 |
@@ -155,6 +157,7 @@ JSON スキーマ `slides.schema.json` を利用できます。IDE の補完や�
 
 動画の場合は `videoId` を省略し、`fileInputId` のみを指定してください。点群ファイルは
 `x y z` や `x,y,z` など空白またはカンマ区切りで `r,g,b` を含めることもできるテキスト（CSV 等）を読み込みます。
+色値は 0-1 または 0-255 のどちらでも構いません。
 ファイルを選択すると、その内容がすぐにスライドへ反映されます。
 
 ### `slides.yaml` の詳細
@@ -220,7 +223,8 @@ editableSlides:
 **pointCloud**
 - `points`: 乱数で生成する点の数（`fileInputId` がない場合に使用）
 - `fileInputId`: ローカルの点群ファイルを読み込む ID
-- `useVertexColors`: `true` のとき r,g,b を含む点群ファイルをカラー表示
+- `pointCloudSrc`: 点群データを含むテキストファイルのパス
+- `useVertexColors`: `true` のとき r,g,b を含む点群ファイルをカラー表示 (値は 0-1 または 0-255 を想定)
 - `caption`: 点群の説明文
 - `zoomable`: 点群表示を拡大するか
 

--- a/main.js
+++ b/main.js
@@ -270,7 +270,13 @@
                                 if (parts.length >= 3 && parts.slice(0, 3).every(n => !isNaN(n))) {
                                     vertices.push(parts[0], parts[1], parts[2]);
                                     if (parts.length >= 6 && parts.slice(3, 6).every(n => !isNaN(n))) {
-                                        colors.push(parts[3], parts[4], parts[5]);
+                                        let [r, g, b] = parts.slice(3, 6);
+                                        if (r > 1 || g > 1 || b > 1) {
+                                            r /= 255;
+                                            g /= 255;
+                                            b /= 255;
+                                        }
+                                        colors.push(r, g, b);
                                     }
                                 }
                             });
@@ -383,13 +389,19 @@
                                     const colors = [];
                                     const lines = text.split('\n');
                                     lines.forEach(line => {
-                                        const parts = line.split(',').map(Number);
-                                        if (parts.length >= 3) {
-                                            vertices.push(parts[0], parts[1], parts[2]);
-                                            if (parts.length >= 6) {
-                                                colors.push(parts[3], parts[4], parts[5]);
+                                    const parts = line.trim().split(/[\s,]+/).map(Number);
+                                    if (parts.length >= 3 && parts.slice(0, 3).every(n => !isNaN(n))) {
+                                        vertices.push(parts[0], parts[1], parts[2]);
+                                        if (parts.length >= 6 && parts.slice(3, 6).every(n => !isNaN(n))) {
+                                            let [r, g, b] = parts.slice(3, 6);
+                                            if (r > 1 || g > 1 || b > 1) {
+                                                r /= 255;
+                                                g /= 255;
+                                                b /= 255;
                                             }
+                                            colors.push(r, g, b);
                                         }
+                                    }
                                     });
                                     slideDataEntry.pointData = { vertices, colors };
                                     initPointCloud(slide.querySelector('.point-cloud-canvas'), index);

--- a/slideTypes.ts
+++ b/slideTypes.ts
@@ -74,6 +74,8 @@ interface PointCloudSlide extends BaseSlide {
     type: 'pointCloud';
     /** Number of random points when no file is provided */
     points?: number;
+    /** Path to a text file containing point data */
+    pointCloudSrc?: string;
     /** Use r,g,b values included in the file */
     useVertexColors?: boolean;
     caption?: string;

--- a/slides.schema.json
+++ b/slides.schema.json
@@ -112,6 +112,7 @@
           "properties": {
             "type": { "const": "pointCloud" },
             "points": { "type": "integer" },
+            "pointCloudSrc": { "type": "string" },
             "useVertexColors": { "type": "boolean" },
             "caption": { "type": "string" }
           }

--- a/slides.yaml
+++ b/slides.yaml
@@ -71,7 +71,7 @@ editableSlides:
     caption: "ローカルのテキストファイル（.txt, .csv）から点群データを読み込み、色付きで表示します。"
     fileInputId: "local-point-cloud"
     useVertexColors: true
-    notes: "ファイル選択ダイアログが表示されます。各行が \"x y z r g b\" または \"x,y,z,r,g,b\" 形式のテキストファイルを選択してください。"
+    notes: "ファイル選択ダイアログが表示されます。各行が \"x y z r g b\" または \"x,y,z,r,g,b\" 形式(色値は0-1または0-255)のテキストファイルを選択してください。"
   - type: image
     header: "4. 拡張機能"
     title: "ローカル画像の読み込み"

--- a/slides_template.yaml
+++ b/slides_template.yaml
@@ -38,6 +38,8 @@ editableSlides:
     points: 20000
     # または pointCloudSrc に点群ファイルのパスを指定できます
     # pointCloudSrc: "data/points.txt"
+    # r,g,b カラー値を使う場合は useVertexColors: true を指定します
+    # useVertexColors: true
     footerText: ""
     notes: ""
 


### PR DESCRIPTION
## Summary
- scale vertex colors from text files if necessary
- add `pointCloudSrc` and document `useVertexColors`
- update templates and examples with color options
- expand schema and TypeScript definitions

## Testing
- `python3 -m py_compile serve.py`
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_6881102c75848327a75106db4b332828