### PR TITLE
Enable automatic vertex colors for point cloud slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ http://localhost:8000/index.html?yaml=Slide/my_presentation.yaml
 
 - type: pointCloud
   pointCloudSrc: "data/points.txt"
-  # RGB 値が含まれるファイルでは useVertexColors: true を指定します
-  # useVertexColors: true
+  # 色付きの点群データは自動的に認識されます
 ```
 
 パスは `index.html` からの相対パスで記述してください。
@@ -224,7 +223,7 @@ editableSlides:
 - `points`: 乱数で生成する点の数（`fileInputId` がない場合に使用）
 - `fileInputId`: ローカルの点群ファイルを読み込む ID
 - `pointCloudSrc`: 点群データを含むテキストファイルのパス
-- `useVertexColors`: `true` のとき r,g,b を含む点群ファイルをカラー表示 (値は 0-1 または 0-255 を想定)
+- `useVertexColors`: `true` を指定すると強制的にカラー表示を行います。省略しても r,g,b 値があれば自動的に判定します (値は 0-1 または 0-255 を想定)
 - `caption`: 点群の説明文
 - `zoomable`: 点群表示を拡大するか
 

--- a/main.js
+++ b/main.js
@@ -286,6 +286,9 @@
                                 }
                             });
                             slideData[slideIndex].pointData = { vertices, colors };
+                            if (colors.length > 0) {
+                                canvas.dataset.useVertexColors = 'true';
+                            }
                             initPointCloud(canvas, slideIndex, isModal);
                         })
                         .catch(err => console.error(`failed to load ${src}`, err));
@@ -302,10 +305,14 @@
                 controls.enableDamping = true;
 
                 const pointsCount = parseInt(canvas.dataset.points) || 0;
-                const useVertexColors = canvas.dataset.useVertexColors === 'true';
-                
+                let useVertexColors = canvas.dataset.useVertexColors === 'true';
+
                 const vertices = slideData[slideIndex].pointData?.vertices || [];
                 const colors = slideData[slideIndex].pointData?.colors || [];
+                if (!useVertexColors && colors.length > 0) {
+                    useVertexColors = true;
+                    canvas.dataset.useVertexColors = 'true';
+                }
 
                 if (pointsCount > 0 && vertices.length === 0) {
                      for (let i = 0; i < pointsCount; i++) {
@@ -394,21 +401,24 @@
                                     const colors = [];
                                     const lines = text.split('\n');
                                     lines.forEach(line => {
-                                    const parts = line.trim().split(/[\s,]+/).map(Number);
-                                    if (parts.length >= 3 && parts.slice(0, 3).every(n => !isNaN(n))) {
-                                        vertices.push(parts[0], parts[1], parts[2]);
-                                        if (parts.length >= 6 && parts.slice(3, 6).every(n => !isNaN(n))) {
-                                            let [r, g, b] = parts.slice(3, 6);
-                                            if (r > 1 || g > 1 || b > 1) {
-                                                r /= 255;
-                                                g /= 255;
-                                                b /= 255;
+                                        const parts = line.trim().split(/[\s,]+/).map(Number);
+                                        if (parts.length >= 3 && parts.slice(0, 3).every(n => !isNaN(n))) {
+                                            vertices.push(parts[0], parts[1], parts[2]);
+                                            if (parts.length >= 6 && parts.slice(3, 6).every(n => !isNaN(n))) {
+                                                let [r, g, b] = parts.slice(3, 6);
+                                                if (r > 1 || g > 1 || b > 1) {
+                                                    r /= 255;
+                                                    g /= 255;
+                                                    b /= 255;
+                                                }
+                                                colors.push(r, g, b);
                                             }
-                                            colors.push(r, g, b);
                                         }
-                                    }
                                     });
                                     slideDataEntry.pointData = { vertices, colors };
+                                    if (colors.length > 0) {
+                                        slide.querySelector('.point-cloud-canvas').dataset.useVertexColors = 'true';
+                                    }
                                     initPointCloud(slide.querySelector('.point-cloud-canvas'), index);
                                 };
                                 reader.readAsText(file);


### PR DESCRIPTION
## Summary
- auto-detect RGB columns in point cloud files
- update README to describe automatic color detection

## Testing
- `python3 -m py_compile serve.py`

------
https://chatgpt.com/codex/tasks/task_e_6881160e7ed08327a0c95b67c99fbf04