### PR TITLE
Add simple remote control via WebSocket

### DIFF
--- a/remote.html
+++ b/remote.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Remote Control</title>
+    <style>
+        body{font-family:sans-serif;text-align:center;margin-top:50px;}
+        button{font-size:1.5em;margin:0.5em;padding:0.5em 1em;}
+    </style>
+</head>
+<body>
+    <button id="prev">Prev</button>
+    <button id="next">Next</button>
+    <script>
+        const httpPort = location.port ? parseInt(location.port,10) : (location.protocol === 'https:' ? 443 : 80);
+        const wsPort = httpPort + 1;
+        const wsProtocol = location.protocol === 'https:' ? 'wss' : 'ws';
+        const ws = new WebSocket(`${wsProtocol}://${location.hostname}:${wsPort}`);
+        document.getElementById('prev').onclick = () => ws.send(JSON.stringify({type:'command',command:'prev'}));
+        document.getElementById('next').onclick = () => ws.send(JSON.stringify({type:'command',command:'next'}));
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend `serve.py` with an asyncio WebSocket server
- broadcast slide and fragment changes
- add a minimal remote control page
- connect slides to the WebSocket server in `main.js`

## Testing
- `pip install websockets`
- `python serve.py --help`
- `python -m py_compile serve.py`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_688118b682c483278a8c9d1579df3722