### PR TITLE
Add script to build Windows executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ data/*
 !data/.gitkeep
 node_modules/
 dist/
+build/

--- a/README.md
+++ b/README.md
@@ -293,6 +293,26 @@ fontScale: 1.25  # 例: 1.5 にすると文字が大きく表示されます
 | `Dockerfile` | Docker イメージ作成用の設定 |
 | `tools/validate_slides.py` | YAML をスキーマで検証するツール |
 
+## Windows向け実行ファイルの作成
+
+Python がインストールされていない環境でも `serve.py` を実行できるよう、
+PyInstaller を利用して単一の実行ファイルを作成できます。
+
+1. 依存パッケージをインストールします。
+
+```bash
+pip install -r requirements.txt
+```
+
+2. ビルドスクリプトを実行します。
+
+```bash
+python tools/build_exe.py
+```
+
+`dist/serve.exe` (Linux では `dist/serve`) が生成されます。
+起動するとサーバーが立ち上がり、自動でブラウザが開きます。
+
 
 
 ## ライセンス

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyinstaller==6.4.0

--- a/tools/build_exe.py
+++ b/tools/build_exe.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Build serve.py into a standalone executable using PyInstaller."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    serve_py = root / "serve.py"
+    subprocess.check_call([
+        "pyinstaller",
+        "--onefile",
+        "--clean",
+        str(serve_py),
+    ])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow packaging of `serve.py` with PyInstaller
- document how to create the Windows executable
- ignore PyInstaller build artifacts

## Testing
- `pip install -r requirements.txt`
- `python tools/build_exe.py`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881953634d88327a8a5f92ad4e8f042