### PR TITLE
Add Node tooling to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,23 @@
 FROM python:3.11-slim
+
+# Install Node.js 20.x
+RUN apt-get update \
+    && apt-get install -y curl gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
 WORKDIR /app
 COPY . /app
+
+# Build frontend assets
+RUN npm install \
+    && npm run build \
+    && npm cache clean --force
+
 EXPOSE 8000
 CMD ["python", "-m", "http.server", "8000"]

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ docker build -t pointcloud-slide .
 docker run --rm -p 8000:8000 pointcloud-slide
 ```
 
+このイメージには Node.js と Python の依存パッケージが含まれているため、
+コンテナ内で `npm run build` や `python tools/validate_slides.py` など
+すべてのコマンドを実行できます。
+
 変更をリアルタイムで反映させながら編集したい場合は、ホストのフォルダをコンテナにマウントします。
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pyinstaller==6.4.0
+PyYAML
+jsonschema


### PR DESCRIPTION
## Summary
- include PyYAML and jsonschema in requirements
- install Node.js and Python deps in Dockerfile and build frontend
- mention available commands in Docker section of README

## Testing
- `python tools/validate_slides.py slides.yaml`

------
https://chatgpt.com/codex/tasks/task_e_688197176b348327a779319afcf72135