### PR TITLE
Use custom server in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN npm install \
     && npm cache clean --force
 RUN rm -rf node_modules
 EXPOSE 8000
-CMD ["python", "-m", "http.server", "8000"]
+CMD ["python", "serve.py", "-p", "8000", "--no-browser"]

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ docker run --rm -p 8000:8000 pointcloud-slide
 
 このイメージには Node.js と Python の依存パッケージが含まれているため、
 コンテナ内で `npm run build` や `python tools/validate_slides.py` など
-すべてのコマンドを実行できます。
+すべてのコマンドを実行できます。起動時には `serve.py` が実行されるため、
+ブラウザの切断による `BrokenPipeError` がログに表示されることはありません。
 
 変更をリアルタイムで反映させながら編集したい場合は、ホストのフォルダをコンテナにマウントします。
 


### PR DESCRIPTION
## Summary
- run `serve.py` instead of `http.server` in Docker
- document the new behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688199819f748327ad141e7172f26e9e