### PR TITLE
Fix theme toggle error

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -33,7 +33,8 @@ export function toggleTheme(
   themes: string[],
   currentIndex: { value: number }
 ) {
-  document.body.classList.remove(themes[currentIndex.value]);
+  const oldTheme = themes[currentIndex.value];
+  if (oldTheme) document.body.classList.remove(oldTheme);
   currentIndex.value = (currentIndex.value + 1) % themes.length;
   const newTheme = themes[currentIndex.value];
   if (newTheme) document.body.classList.add(newTheme);


### PR DESCRIPTION
## Summary
- prevent removing empty class name when cycling themes

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68819ba174588327ad17efc9a37d9198